### PR TITLE
Fix halt behavior in simulator.

### DIFF
--- a/js/sx86-display.js
+++ b/js/sx86-display.js
@@ -80,7 +80,7 @@
 
 
   exports.next_step_update_display = function() {
-    if ((sx86.mem.ram[sx86.mem.regs[6]] >= 0x0000) && (sx86.mem.ram[sx86.mem.regs[6]] <= 0xffff)) { // Treat negative values as halt
+    if ((sx86.mem.ram[sx86.mem.regs[6]] > 0x0000) && (sx86.mem.ram[sx86.mem.regs[6]] <= 0xffff)) { // Treat negative values as halt
       sx86.step();
       exports.update_display();
     } 
@@ -93,7 +93,7 @@
       exports.running = 1;
       }
     } else {
-      while ((sx86.mem.ram[sx86.mem.regs[6]] >= 0x0000) && (sx86.mem.ram[sx86.mem.regs[6]] <= 0xffff)){
+      while ((sx86.mem.ram[sx86.mem.regs[6]] > 0x0000) && (sx86.mem.ram[sx86.mem.regs[6]] <= 0xffff)){
         sx86.step();
       }
       exports.update_display();

--- a/js/sx86.js
+++ b/js/sx86.js
@@ -71,7 +71,9 @@
     instruction = exports.__fetch();
     op_code = (instruction & 0xF000) >> 12;
     switch (op_code) {
-      case 0x0: break;// HALT
+      case 0x0: // HALT
+	exports.mem.flags.halt = true;
+	break;
       case 0x1: // INC Rn
         // All registers are 16 bits. 0-1 = 0. 0xffff + 1 = 0
         parameter = instruction & 0x0FFF;            
@@ -181,6 +183,9 @@
     }
 
     exports.__decode();
+    if (exports.mem.flags.halt === true) {
+	return;
+    }
 
     if (exports.mem.flags.jmp === 0) {
       exports.mem.regs[6] += 1;


### PR DESCRIPTION
As written, halt behaves like a no-op. This is almost certainly
unintended behavior. The attached patch should fix this.
